### PR TITLE
Use the new security.token_storage from symfony > 2.7 compatibility

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,7 +23,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument>%lexik_jwt_authentication.token_ttl%</argument>
             <call method="setRequest">
-                <argument type="service" id="request" on-invalid="null" strict="false" />
+                <argument type="service" id="request" on-invalid="null" />
             </call>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -49,7 +49,7 @@
         </service>
         <!-- JWT Security Authentication Listener -->
         <service id="lexik_jwt_authentication.security.authentication.listener" class="%lexik_jwt_authentication.security.authentication.listener.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Options -->
         </service>

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -40,7 +40,7 @@ class JWTListener implements ListenerInterface
     protected $tokenExtractors;
 
     /**
-     * @param SecurityContextInterface       $securityoCntext
+     * @param SecurityContextInterface       $securityContext
      * @param AuthenticationManagerInterface $authenticationManager
      * @param array                          $config
      */

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -22,7 +22,7 @@ class JWTListener implements ListenerInterface
     /**
      * @var TokenStorageInterface
      */
-    protected $securityContext;
+    protected $tokenStorage;
 
     /**
      * @var AuthenticationManagerInterface
@@ -40,13 +40,13 @@ class JWTListener implements ListenerInterface
     protected $tokenExtractors;
 
     /**
-     * @param SecurityContextInterface       $securityContext
+     * @param TokenStorageInterface          $tokenStorage
      * @param AuthenticationManagerInterface $authenticationManager
      * @param array                          $config
      */
     public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, array $config = array())
     {
-        $this->tokenStorage       = $tokenStorage;
+        $this->tokenStorage          = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->config                = array_merge(array('throw_exceptions' => false), $config);
         $this->tokenExtractors       = array();

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 
 /**
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 class JWTListener implements ListenerInterface
 {
     /**
-     * @var SecurityContextInterface
+     * @var TokenStorageInterface
      */
     protected $securityContext;
 
@@ -40,13 +40,13 @@ class JWTListener implements ListenerInterface
     protected $tokenExtractors;
 
     /**
-     * @param SecurityContextInterface       $securityContext
+     * @param SecurityContextInterface       $securityoCntext
      * @param AuthenticationManagerInterface $authenticationManager
      * @param array                          $config
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, array $config = array())
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, array $config = array())
     {
-        $this->securityContext       = $securityContext;
+        $this->tokenStorage       = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->config                = array_merge(array('throw_exceptions' => false), $config);
         $this->tokenExtractors       = array();
@@ -65,12 +65,11 @@ class JWTListener implements ListenerInterface
         $token->setRawToken($requestToken);
 
         try {
-
             $authToken = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($authToken);
+
+            $this->tokenStorage->setToken($authToken);
 
             return;
-
         } catch (AuthenticationException $failed) {
             if ($this->config['throw_exceptions']) {
                 throw $failed;

--- a/Tests/Security/Authentication/Firewall/JWTListenerTest.php
+++ b/Tests/Security/Authentication/Firewall/JWTListenerTest.php
@@ -18,12 +18,12 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
     {
         // no token extractor : should return void
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $this->getAuthenticationManagerMock());
+        $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
         $this->assertNull($listener->handle($this->getEvent()));
 
         // one token extractor with no result : should return void
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $this->getAuthenticationManagerMock());
+        $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock(false));
         $this->assertNull($listener->handle($this->getEvent()));
 
@@ -32,7 +32,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
         $authenticationManager = $this->getAuthenticationManagerMock();
         $authenticationManager->expects($this->once())->method('authenticate');
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $authenticationManager);
+        $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
         $listener->handle($this->getEvent());
 
@@ -47,7 +47,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
             ->method('authenticate')
             ->will($this->throwException(new \Symfony\Component\Security\Core\Exception\AuthenticationException()));
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $authenticationManager);
+        $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
 
         $event = $this->getEvent();
@@ -70,10 +70,10 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    public function getSecurityContextMock()
+    public function getTokenStorageMock()
     {
         return $this
-            ->getMockBuilder('Symfony\Component\Security\Core\SecurityContext')
+            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
             ->disableOriginalConstructor()
             ->getMock();
     }


### PR DESCRIPTION
These changes enable the jwt-authentication-bundle to have Symfony > 2.7 compatibility.

I've changed the security.context service usage to security.token_storage.