### PR TITLE
Use the new security.token_storage from symfony > 2.7 compatibility

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,7 +23,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument>%lexik_jwt_authentication.token_ttl%</argument>
             <call method="setRequest">
-                <argument type="service" id="request" on-invalid="null" strict="false" />
+                <argument type="service" id="request" on-invalid="null" />
             </call>
             <call method="setUserIdentityField">
                 <argument>%lexik_jwt_authentication.user_identity_field%</argument>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -49,7 +49,7 @@
         </service>
         <!-- JWT Security Authentication Listener -->
         <service id="lexik_jwt_authentication.security.authentication.listener" class="%lexik_jwt_authentication.security.authentication.listener.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Options -->
         </service>

--- a/Security/Authentication/Provider/JWTProvider.php
+++ b/Security/Authentication/Provider/JWTProvider.php
@@ -47,7 +47,9 @@ class JWTProvider implements AuthenticationProviderInterface
      */
     public function authenticate(TokenInterface $token)
     {
-        if (!($payload = $this->jwtManager->decode($token))) {
+        $payload = $this->jwtManager->decode($token);
+
+        if (empty($payload)) {
             throw new AuthenticationException('Invalid JWT Token');
         }
 

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -40,7 +40,7 @@ class JWTListener implements ListenerInterface
     protected $tokenExtractors;
 
     /**
-     * @param SecurityContextInterface       $securityoCntext
+     * @param SecurityContextInterface       $securityContext
      * @param AuthenticationManagerInterface $authenticationManager
      * @param array                          $config
      */

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -22,7 +22,7 @@ class JWTListener implements ListenerInterface
     /**
      * @var TokenStorageInterface
      */
-    protected $securityContext;
+    protected $tokenStorage;
 
     /**
      * @var AuthenticationManagerInterface
@@ -40,13 +40,13 @@ class JWTListener implements ListenerInterface
     protected $tokenExtractors;
 
     /**
-     * @param SecurityContextInterface       $securityContext
+     * @param TokenStorageInterface          $tokenStorage
      * @param AuthenticationManagerInterface $authenticationManager
      * @param array                          $config
      */
     public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, array $config = array())
     {
-        $this->tokenStorage       = $tokenStorage;
+        $this->tokenStorage          = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->config                = array_merge(array('throw_exceptions' => false), $config);
         $this->tokenExtractors       = array();

--- a/Security/Firewall/JWTListener.php
+++ b/Security/Firewall/JWTListener.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 
 /**
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 class JWTListener implements ListenerInterface
 {
     /**
-     * @var SecurityContextInterface
+     * @var TokenStorageInterface
      */
     protected $securityContext;
 
@@ -40,13 +40,13 @@ class JWTListener implements ListenerInterface
     protected $tokenExtractors;
 
     /**
-     * @param SecurityContextInterface       $securityContext
+     * @param SecurityContextInterface       $securityoCntext
      * @param AuthenticationManagerInterface $authenticationManager
      * @param array                          $config
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, array $config = array())
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, array $config = array())
     {
-        $this->securityContext       = $securityContext;
+        $this->tokenStorage       = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->config                = array_merge(array('throw_exceptions' => false), $config);
         $this->tokenExtractors       = array();
@@ -65,12 +65,11 @@ class JWTListener implements ListenerInterface
         $token->setRawToken($requestToken);
 
         try {
-
             $authToken = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($authToken);
+
+            $this->tokenStorage->setToken($authToken);
 
             return;
-
         } catch (AuthenticationException $failed) {
             if ($this->config['throw_exceptions']) {
                 throw $failed;

--- a/Tests/Security/Authentication/Firewall/JWTListenerTest.php
+++ b/Tests/Security/Authentication/Firewall/JWTListenerTest.php
@@ -18,12 +18,12 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
     {
         // no token extractor : should return void
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $this->getAuthenticationManagerMock());
+        $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
         $this->assertNull($listener->handle($this->getEvent()));
 
         // one token extractor with no result : should return void
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $this->getAuthenticationManagerMock());
+        $listener = new JWTListener($this->getTokenStorageMock(), $this->getAuthenticationManagerMock());
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock(false));
         $this->assertNull($listener->handle($this->getEvent()));
 
@@ -32,7 +32,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
         $authenticationManager = $this->getAuthenticationManagerMock();
         $authenticationManager->expects($this->once())->method('authenticate');
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $authenticationManager);
+        $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
         $listener->handle($this->getEvent());
 
@@ -47,7 +47,7 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
             ->method('authenticate')
             ->will($this->throwException(new \Symfony\Component\Security\Core\Exception\AuthenticationException()));
 
-        $listener = new JWTListener($this->getSecurityContextMock(), $authenticationManager);
+        $listener = new JWTListener($this->getTokenStorageMock(), $authenticationManager);
         $listener->addTokenExtractor($this->getAuthorizationHeaderTokenExtractorMock('token'));
 
         $event = $this->getEvent();
@@ -70,10 +70,10 @@ class JWTListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    public function getSecurityContextMock()
+    public function getTokenStorageMock()
     {
         return $this
-            ->getMockBuilder('Symfony\Component\Security\Core\SecurityContext')
+            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Security/Authentication/Provider/JWTProviderTest.php
+++ b/Tests/Security/Authentication/Provider/JWTProviderTest.php
@@ -98,7 +98,7 @@ class JWTProviderTest extends \PHPUnit_Framework_TestCase
         $userProvider->expects($this->any())->method('loadUserByUsername')->willThrowException(new UsernameNotFoundException());
 
         $jwtManager = $this->getJWTManagerMock();
-        $jwtManager->expects($this->any())->method('decode')->will($this->returnValue(array('username' => 'user')));
+        $jwtManager->expects($this->any())->method('decode')->will($this->returnValue([ 'user' => [ 'username' => 'xyzzy' ] ]));
 
         $provider = new JWTProvider($userProvider, $jwtManager);
         $provider->authenticate($jwtUserToken);
@@ -125,7 +125,7 @@ class JWTProviderTest extends \PHPUnit_Framework_TestCase
         $userProvider->expects($this->any())->method('loadUserByUsername')->will($this->returnValue($user));
 
         $jwtManager = $this->getJWTManagerMock();
-        $jwtManager->expects($this->any())->method('decode')->will($this->returnValue(array('username' => 'user')));
+        $jwtManager->expects($this->any())->method('decode')->will($this->returnValue([ 'user' => [ 'username' => 'user' ] ]));
 
         $provider = new JWTProvider($userProvider, $jwtManager);
 
@@ -137,7 +137,7 @@ class JWTProviderTest extends \PHPUnit_Framework_TestCase
         // test changing user identity field
 
         $jwtManager = $this->getJWTManagerMock();
-        $jwtManager->expects($this->any())->method('decode')->will($this->returnValue(array('uid' => 'user')));
+        $jwtManager->expects($this->any())->method('decode')->will($this->returnValue([ 'user' => [ 'uid' => 'user' ] ]));
 
         $provider = new JWTProvider($userProvider, $jwtManager);
         $provider->setUserIdentityField('uid');

--- a/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
@@ -17,7 +17,8 @@ class AuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnAuthenticationFailure()
     {
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+            ->getMock();
 
         $handler = new AuthenticationFailureHandler($dispatcher);
         $response = $handler->onAuthenticationFailure($this->getRequest(), $this->getAuthenticationException());

--- a/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/Tests/Security/Http/Authentication/AuthenticationSuccessHandlerTest.php
@@ -77,7 +77,10 @@ class AuthenticationSuccessHandlerTest extends \PHPUnit_Framework_TestCase
     protected function getToken()
     {
         $user = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')
+            ->getMockBuilder([
+                'Lexik\Bundle\JWTAuthenticationBundle\User\JWTUserInterface',
+                'Symfony\Component\Security\Core\User\UserInterface',
+            ])
             ->getMock();
 
         $user

--- a/Tests/Services/JWTManagerTest.php
+++ b/Tests/Services/JWTManagerTest.php
@@ -35,7 +35,7 @@ class JWTManagerTest extends \PHPUnit_Framework_TestCase
             ->willReturn('secrettoken');
 
         $manager = new JWTManager($encoder, $dispatcher, 3600);
-        $this->assertEquals('secrettoken', $manager->create(new User('user', 'password')));
+        $this->assertEquals('secrettoken', $manager->create(new CustomUser('user', 'password')));
     }
 
     /**

--- a/Tests/Stubs/User.php
+++ b/Tests/Stubs/User.php
@@ -12,6 +12,8 @@
 namespace Lexik\Bundle\JWTAuthenticationBundle\Tests\Stubs;
 
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\User\JWTUserInterface;
+
 /**
  * User is the user implementation used by the in-memory user provider.
  *
@@ -19,7 +21,7 @@ use Symfony\Component\Security\Core\User\AdvancedUserInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class User implements AdvancedUserInterface
+final class User implements AdvancedUserInterface, JWTUserInterface
 {
     private $username;
     private $password;
@@ -60,6 +62,14 @@ final class User implements AdvancedUserInterface
     public function getPassword()
     {
         return $this->password;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPayload()
+    {
+        return [ 'username' => $this->username ];
     }
 
     /**


### PR DESCRIPTION
These changes enable the jwt-authentication-bundle to have Symfony > 2.7 compatibility.

I've changed the security.context service usage to security.token_storage.